### PR TITLE
Add a display formatter

### DIFF
--- a/app/models/concerns/spree/loyalty_points.rb
+++ b/app/models/concerns/spree/loyalty_points.rb
@@ -4,6 +4,19 @@ module Spree
   module LoyaltyPoints
     extend ActiveSupport::Concern
 
+    class IntegerPointFormat
+      def display object, points
+        points.to_s
+      end
+    end
+
+    @@loyalty_points_format = IntegerPointFormat.new
+    mattr_accessor :loyalty_points_format
+
+    def loyalty_points_display(amount)
+      @@loyalty_points_format.display self, amount
+    end
+
     def loyalty_points_for(amount, purpose = 'award')
       loyalty_points = if purpose == 'award' && eligible_for_loyalty_points?(amount)
         (amount * Spree::Config.loyalty_points_awarding_unit).floor

--- a/app/overrides/add_loyalty_points_to_cart_page.rb
+++ b/app/overrides/add_loyalty_points_to_cart_page.rb
@@ -3,6 +3,6 @@ Deface::Override.new(:virtual_path => 'spree/orders/edit',
   :insert_after => "#subtotal h5",
   :text => "
     <% if @order.loyalty_points_for(@order.item_total) > 0 %>
-      <h5><%= Spree.t(:loyalty_points_earnable, :quantity => \"<span class='order-total'> \#{@order.loyalty_points_for(@order.item_total)}</span>\").html_safe %></h5>
+      <h5><%= Spree.t(:loyalty_points_earnable, :quantity => \"<span class='order-total'> \#{@order.loyalty_points_display(@order.loyalty_points_for(@order.item_total))}</span>\").html_safe %></h5>
     <% end %>
   ")

--- a/app/overrides/add_loyalty_points_to_order_checkout_page.rb
+++ b/app/overrides/add_loyalty_points_to_order_checkout_page.rb
@@ -6,10 +6,10 @@ Deface::Override.new(:virtual_path => 'spree/shared/_order_details',
       <tr id='loyalty-points-row'>
         <% if @order.loyalty_points_awarded? %>
           <td></td>
-          <td colspan='4' class='total'><span><%= @order.loyalty_points_for(@order.item_total) %></span> <b><%= Spree.t(:loyalty_points) %> have been credited to your account.</b></td>
+          <td colspan='4' class='total'><span><%= @order.loyalty_points_display(@order.loyalty_points_for(@order.item_total)) %></span> <b><%= Spree.t(:loyalty_points) %> have been credited to your account.</b></td>
         <% else %>
           <td></td>
-          <td colspan='4' class='total'><span><%= @order.loyalty_points_for(@order.item_total) %></span> <b><%= Spree.t(:loyalty_points) %> will be credited to your account  soon.</b></td>
+          <td colspan='4' class='total'><span><%= @order.loyalty_points_display(@order.loyalty_points_for(@order.item_total)) %></span> <b><%= Spree.t(:loyalty_points) %> will be credited to your account  soon.</b></td>
         <% end %>
       </tr>
     </tfoot>

--- a/app/views/spree/checkout/payment/_loyaltypoints.html.erb
+++ b/app/views/spree/checkout/payment/_loyaltypoints.html.erb
@@ -1,7 +1,7 @@
 <%- lp_balance = spree_current_user.loyalty_points_balance %>
 <%- equivalent_currency_balance = spree_current_user.loyalty_points_equivalent_currency %>
 Loyalty Points Balance: <%= lp_balance %><%= "($" + equivalent_currency_balance.to_s + ")" %>
-<%- lp_needed = @order.loyalty_points_for(@order.total, 'redeem') %>
+<%- lp_needed = @order.loyalty_points_display(@order.loyalty_points_for(@order.total, 'redeem')) %>
 <br/>Loyalty Points Needed: <%= lp_needed %>
 <% if lp_needed > lp_balance %>
   <br/><b>Insufficient Balance!</b>

--- a/spec/models/concerns/spree/loyalty_points_spec.rb
+++ b/spec/models/concerns/spree/loyalty_points_spec.rb
@@ -1,5 +1,13 @@
 shared_examples_for "LoyaltyPoints" do
 
+  describe 'loyalty_points_display' do
+
+    it 'returns the same amount of points' do
+      resource_instance.loyalty_points_display(100).should eq '100'
+    end
+
+  end
+
   describe 'loyalty_points_for' do
 
     context "when purpose is to award" do


### PR DESCRIPTION
Hi!

To start off this PR I'd like to give you a heads up that we're going to be using this extension for a project we're currently working on. So to start off, thanks! We're going to shoot you off a number of PR's to add functionality or more easily extend spree-loyalty-points for the project we're working on. Please feel free to take the ones you want and ignore the ones you don't.

Since we're currently working on spree 2-1, I'm going to send the PR's against stable for now. if you think that any of this is functionality you'd like in master, let me know and I'll get them to cleanly apply to there.

This first PR allows customization of the way points are displayed to end-users. The straight integers weren't enough for us, but with this customization we are able to easily change the way points are displayed to a user. For instance, to make it look more like money, I could do something like:

``` ruby
class DecimalPointFormat
  def display object, points
    ::Money.new(points, object.currency).format
  end
end
Spree::LoyaltyPoints.loyalty_points_format = DecimalPointFormat.new
```
